### PR TITLE
Update devcontainer to use 16gb RAM

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,10 @@
 	// Use 'postStartCommand' to run commands after the container is started (more frequently than create).
 	"postStartCommand": "pip3 install --user -r requirements.txt",
 
+    "hostRequirements": {
+        "memory": "16gb"
+    },
+
     // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }


### PR DESCRIPTION
With the latest Ollama update, trying to run the model with the default container configuration (with 8gb RAM) fails most of the time. This fixes the issue by requirement a devcontainer with more RAM by default